### PR TITLE
Removed notice about auto-creating containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ npm install --save-dev nx-remotecache-azure
 }
 ```
 
-> Note: If `nx-remotecache-azure` is not finding a container with the specificed name, it will create a new one.
-
 ## Run it 🚀
 
 Running tasks should now show the storage or retrieval from the remote cache:


### PR DESCRIPTION
As we are now only using the BlockBlobClient, we can no longer auto-create the container for the user.